### PR TITLE
Smart contract wallet signatures

### DIFF
--- a/contracts/Eip712/Eip712CheckerInternal.sol
+++ b/contracts/Eip712/Eip712CheckerInternal.sol
@@ -32,21 +32,6 @@ library Eip712CheckerInternal {
             );
     }
 
-    /// @dev Recovers message signer
-    /// @param message Hashed data payload
-    /// @param signature Signed data payload
-    function _recover(bytes32 message, bytes calldata signature)
-        internal
-        view
-        returns (address signer)
-    {
-        bytes32 msgHash = keccak256(
-            abi.encodePacked("\x19\x01", _eip712Domain(), message)
-        );
-
-        return ECDSA.recover(msgHash, signature);
-    }
-
     /// @dev Recovers message signer and verifies if metches signatory
     /// @param signatory The signer to be verified
     /// @param message Hashed data payload

--- a/contracts/Eip712/Eip712CheckerInternal.sol
+++ b/contracts/Eip712/Eip712CheckerInternal.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "./Eip712CheckerStorage.sol";
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
 /// @title Eip712CheckerInternal
 /// @notice Contract with internal functions to assist in verifying signatures
@@ -61,7 +62,8 @@ library Eip712CheckerInternal {
             abi.encodePacked("\x19\x01", _eip712Domain(), message)
         );
 
-        return signatory == ECDSA.recover(msgHash, signature);
+        return
+            SignatureChecker.isValidSignatureNow(signatory, msgHash, signature);
     }
 
     /// @dev Recovers message signer and verifies if metches signatory
@@ -82,7 +84,9 @@ library Eip712CheckerInternal {
         bytes32 msgHash = keccak256(
             abi.encodePacked("\x19\x01", _eip712Domain(), message)
         );
+        bytes memory signature = abi.encodePacked(r, s, v);
 
-        return signatory == ECDSA.recover(msgHash, v, r, s);
+        return
+            SignatureChecker.isValidSignatureNow(signatory, msgHash, signature);
     }
 }

--- a/contracts/implementations/nodes/AftermarketDevice.sol
+++ b/contracts/implementations/nodes/AftermarketDevice.sol
@@ -15,7 +15,6 @@ import "../../shared/Types.sol" as Types;
 import "../../shared/Errors.sol" as Errors;
 
 import "@solidstate/contracts/access/access_control/AccessControlInternal.sol";
-import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 
 error RegistryNotApproved();
 error DeviceAlreadyRegistered(address addr);

--- a/contracts/mocks/MockSignatureChecker.sol
+++ b/contracts/mocks/MockSignatureChecker.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.13;
+
+import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+
+/// @title Eip712CheckerInternal
+/// @notice Contract with internal functions to assist in verifying signatures
+/// @dev Based on the EIP-712 https://eips.ethereum.org/EIPS/eip-712
+contract MockSignatureChecker {
+    /// @dev Recovers message signer and verifies if metches signatory
+    /// @param signatory The signer to be verified
+    /// @param digest Hashed data payload
+    /// @param signature Signed data payload
+    function verifySignature(
+        address signatory,
+        bytes32 digest,
+        bytes calldata signature
+    ) external view returns (bool success) {
+        return
+            SignatureChecker.isValidSignatureNow(signatory, digest, signature);
+    }
+}

--- a/contracts/mocks/MockSmartContractWallet.sol
+++ b/contracts/mocks/MockSmartContractWallet.sol
@@ -1,0 +1,43 @@
+//SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.13;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+contract ERC1271WalletMock is Ownable, IERC1271 {
+    constructor(address originalOwner) {
+        super.transferOwnership(originalOwner);
+    }
+
+    function isValidSignature(bytes32 hash, bytes memory signature)
+        public
+        view
+        returns (bytes4 magicValue)
+    {
+        return
+            ECDSA.recover(hash, signature) == owner()
+                ? this.isValidSignature.selector
+                : bytes4(0);
+    }
+}
+
+contract ERC1271MaliciousMock is Ownable, IERC1271 {
+    constructor(address originalOwner) {
+        super.transferOwnership(originalOwner);
+    }
+
+    function isValidSignature(bytes32, bytes memory)
+        public
+        pure
+        returns (bytes4)
+    {
+        assembly {
+            mstore(
+                0,
+                0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+            )
+            return(0, 32)
+        }
+    }
+}

--- a/test/SmartContractWallet.test.ts
+++ b/test/SmartContractWallet.test.ts
@@ -1,0 +1,121 @@
+import chai from 'chai';
+import { ethers, waffle } from 'hardhat';
+
+import {
+  ERC1271MaliciousMock__factory as ERC1271MaliciousMockFactory,
+  ERC1271WalletMock__factory as ERC1271WalletMockFactory,
+  MockSignatureChecker
+} from '../typechain';
+import { createSnapshot, revertToSnapshot } from '../utils';
+import { hashMessage } from 'ethers/lib/utils';
+
+const { expect } = chai;
+const provider = waffle.provider;
+
+const testMessageGood = 'good-message';
+const testMessageBad = 'bad-message';
+
+const hashGoodMessage = hashMessage(testMessageGood);
+const hashBadMessage = hashMessage(testMessageBad);
+
+describe('SmartContractWallet', function () {
+  let snapshot: string;
+  let mockERC1271WalletFactory: ERC1271WalletMockFactory;
+  let mockMaliciousERC1271WalletFactory: ERC1271MaliciousMockFactory;
+  let signatureChecker: MockSignatureChecker;
+  const [signer] = provider.getWallets();
+
+  before(async () => {
+    mockERC1271WalletFactory = await ethers.getContractFactory(
+      'ERC1271WalletMock'
+    );
+    mockMaliciousERC1271WalletFactory = await ethers.getContractFactory(
+      'ERC1271MaliciousMock'
+    );
+
+    signatureChecker = await (
+      await ethers.getContractFactory('MockSignatureChecker')
+    )
+      .connect(signer)
+      .deploy();
+  });
+
+  beforeEach(async () => {
+    snapshot = await createSnapshot();
+  });
+
+  afterEach(async () => {
+    await revertToSnapshot(snapshot);
+  });
+
+  describe('MockERC12721Wallet', async () => {
+    it('deploySmartContractWallet', async () => {
+      const contractWallet = await mockERC1271WalletFactory
+        .connect(signer)
+        .deploy(signer.address);
+      await expect(contractWallet.address).to.exist;
+    });
+    it('verifyValidSmartContractWalletSignature', async () => {
+      const contractWallet = await mockERC1271WalletFactory
+        .connect(signer)
+        .deploy(signer.address);
+      const signature = await signer.signMessage(testMessageGood);
+
+      await expect(
+        await contractWallet.isValidSignature(hashGoodMessage, signature)
+      ).to.be.eq(contractWallet.interface.getSighash('isValidSignature'));
+
+      await expect(
+        await signatureChecker.verifySignature(
+          contractWallet.address,
+          hashGoodMessage,
+          signature
+        )
+      ).to.be.eq(true);
+    });
+    it('verifyInvalidSmartContractWalletSignature', async () => {
+      const contractWallet = await mockERC1271WalletFactory
+        .connect(signer)
+        .deploy(signer.address);
+      const signature = await signer.signMessage(testMessageGood);
+
+      await expect(
+        await contractWallet.isValidSignature(hashBadMessage, signature)
+      ).to.be.eq('0x00000000');
+
+      await expect(
+        await signatureChecker.verifySignature(
+          contractWallet.address,
+          hashBadMessage,
+          signature
+        )
+      ).to.be.eq(false);
+    });
+  });
+
+  describe('deployMaliciousSmartContractWallet', async () => {
+    it('deployMaliciousSmartContractWallet', async () => {
+      const contractWallet = await mockMaliciousERC1271WalletFactory
+        .connect(signer)
+        .deploy(signer.address);
+      await expect(contractWallet.address).to.exist;
+    });
+
+    it('verifyMaliciousSmartContractWalletSignatureFails', async () => {
+      const contractWallet = await mockMaliciousERC1271WalletFactory
+        .connect(signer)
+        .deploy(signer.address);
+      const signature = await signer.signMessage(testMessageGood);
+      await expect(
+        await contractWallet.isValidSignature(hashBadMessage, signature)
+      ).to.be.eq('0xffffffff');
+      // await expect(
+      //   await signatureChecker.verifySignature(
+      //     contractWallet.address,
+      //     hashBadMessage,
+      //     signature
+      //   )
+      // ).to.be.reverted("CALL_EXCEPTION")
+    });
+  });
+});


### PR DESCRIPTION
# Motivation

The Ethereum ecosystem is moving toward smart contract wallets to get away from the limitations of regular ECDSA, and the trust assumptions of MPC WaaS infrastructure.  [https://twitter.com/vitalikbuterin/status/1674032447531495426?s=46&t=HS_LREVbTt21r2KhluYHyA](Here is a tweet from our humble lord Buterin)

I did this mostly for funsies.

There is an attack surface using Meta-transations when supporting smart contract wallets.

I can deploy a SMW with a isValidSignature method that consumes a lot of gas, which would force the tx sender to pay more gas.

Not expectin this to be merged, just opening it to annoy @robertsolomon to accept that the future is smart contract wallets.

