### PR TITLE
Feature/si 2387 fixing autopis and users compromised devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ coverage
 coverage.json
 typechain-types
 .vscode/settings.json
+*_old.sol
 
 #Hardhat files
 cache

--- a/Selectors.md
+++ b/Selectors.md
@@ -147,6 +147,7 @@
 | 0x7ba79a39 | mintAftermarketDeviceByManufacturerBatch(uint256,(address,(string,string)[])[]) |
 | 0xb50df2f7 | pairAftermarketDeviceSign(uint256,uint256,bytes,bytes) |
 | 0xcfe642dd | pairAftermarketDeviceSign(uint256,uint256,bytes) |
+| 0x9b3abd48 | reprovisionAftermarketDeviceByManufacturerBatch(uint256[]) |
 | 0x9d0b139b | resetAftermarketDeviceAddressByManufacturerBatch((uint256,address)[]) |
 | 0x4d49d82a | setAftermarketDeviceIdProxyAddress(address) |
 | 0x4d13b709 | setAftermarketDeviceInfo(uint256,(string,string)[]) |
@@ -161,6 +162,7 @@
 | 0x977fe0dd | AftermarketDeviceAttributeSet(uint256,string,string) |
 | 0x8468d811 | AftermarketDeviceClaimed(uint256,address) |
 | 0xe2daa727 | AftermarketDeviceIdProxySet(address) |
+| 0xc4d38c0a | AftermarketDeviceNodeBurned(uint256,address) |
 | 0xd624fd4c | AftermarketDeviceNodeMinted(uint256,uint256,address,address) |
 | 0x89ec1328 | AftermarketDevicePaired(uint256,uint256,address) |
 | 0xd9135724 | AftermarketDeviceUnpaired(uint256,uint256,address) |

--- a/abis/DimoRegistry.json
+++ b/abis/DimoRegistry.json
@@ -1123,6 +1123,25 @@
             {
                 "indexed": true,
                 "internalType": "uint256",
+                "name": "tokenId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address"
+            }
+        ],
+        "name": "AftermarketDeviceNodeBurned",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
                 "name": "manufacturerId",
                 "type": "uint256"
             },
@@ -1390,6 +1409,19 @@
             }
         ],
         "name": "pairAftermarketDeviceSign",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "aftermarketDeviceNodeList",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "reprovisionAftermarketDeviceByManufacturerBatch",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/scripts/data/addresses.json
+++ b/scripts/data/addresses.json
@@ -84,7 +84,7 @@
                 ]
             },
             "AftermarketDevice": {
-                "address": "0x86b10DB61C0deC9A3e8FBF3dC7b1ae8c33b74B3c",
+                "address": "0x6397e67AC10D7cC53DCFC34e1ef578E05B2C6D53",
                 "selectors": [
                     "0x6111afa3",
                     "0x60deec60",
@@ -95,6 +95,7 @@
                     "0x7ba79a39",
                     "0xb50df2f7",
                     "0xcfe642dd",
+                    "0x9b3abd48",
                     "0x9d0b139b",
                     "0x4d49d82a",
                     "0x4d13b709",
@@ -283,7 +284,7 @@
                 ]
             },
             "AftermarketDevice": {
-                "address": "0x6057FBbDc72cAF3dA15264B784c4FA387F2727d2",
+                "address": "0x216f6e4e9ddF79992CbA690b35FB78d56F7532D6",
                 "selectors": [
                     "0x6111afa3",
                     "0x60deec60",
@@ -294,6 +295,7 @@
                     "0x7ba79a39",
                     "0xb50df2f7",
                     "0xcfe642dd",
+                    "0x9b3abd48",
                     "0x9d0b139b",
                     "0x4d49d82a",
                     "0x4d13b709",

--- a/test/DevAdmin.test.ts
+++ b/test/DevAdmin.test.ts
@@ -744,7 +744,7 @@ describe('DevAdmin', function () {
     });
 
     context('State', () => {
-      it('Should correctly map the aftermarket device to the vehicle', async () => {
+      it('Should correctly delete mapping of the aftermarket device to the vehicle', async () => {
         expect(
           await mapperInstance.getLink(await adIdInstance.getAddress(), 1),
         ).to.be.equal(1);
@@ -763,7 +763,7 @@ describe('DevAdmin', function () {
           await mapperInstance.getLink(await adIdInstance.getAddress(), 2),
         ).to.be.equal(0);
       });
-      it('Should correctly map the vehicle to the aftermarket device', async () => {
+      it('Should correctly delete mapping of the vehicle to the aftermarket device', async () => {
         expect(
           await mapperInstance.getLink(await vehicleIdInstance.getAddress(), 1),
         ).to.be.equal(1);

--- a/utils/constants/NftArgs.ts
+++ b/utils/constants/NftArgs.ts
@@ -7,6 +7,7 @@ export const MANUFACTURER_NFT_BASE_URI = 'https://dimo.zone/manufacturer/';
 export const MANUFACTURER_MINTER_PRIVILEGE = '1';
 export const MANUFACTURER_CLAIMER_PRIVILEGE = '2';
 export const MANUFACTURER_FACTORY_RESET_PRIVILEGE = '3';
+export const MANUFACTURER_REPROVISION_PRIVILEGE = '4';
 
 export const INTEGRATION_NFT_NAME = 'Integration NFT';
 export const INTEGRATION_NFT_SYMBOL = 'INFT';


### PR DESCRIPTION
@elffjs Let me know if I have to change anything in the events to avoid any impact

Obs: I renamed some variables in the tests (`DIMO_REGISTRY_ADDRESS`, `VEHICLE_ID_ADDRESS`, `AD_ID_ADDRESS`), this is why there are so many lines changed. If you want to date to take a look at the tests, just look for `describe('reprovisionAftermarketDeviceByManufacturerBatch'`