### PR TITLE
Restore Streamr integration

### DIFF
--- a/abis/contracts/NFTs/VehicleId.sol/VehicleId.json
+++ b/abis/contracts/NFTs/VehicleId.sol/VehicleId.json
@@ -470,6 +470,19 @@
   {
     "inputs": [
       {
+        "internalType": "contract ISacdListener",
+        "name": "listener",
+        "type": "address"
+      }
+    ],
+    "name": "addSacdListener",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "to",
         "type": "address"
@@ -813,6 +826,34 @@
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "grantee",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "permissions",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expiration",
+        "type": "uint256"
+      }
+    ],
+    "name": "onSetPermissions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
       }
     ],
     "name": "ownerOf",
@@ -929,6 +970,19 @@
   {
     "inputs": [
       {
+        "internalType": "contract ISacdListener",
+        "name": "listener",
+        "type": "address"
+      }
+    ],
+    "name": "removeSacdListener",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "role",
         "type": "bytes32"
@@ -968,6 +1022,25 @@
     "outputs": [
       {
         "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "sacdListeners",
+    "outputs": [
+      {
+        "internalType": "contract ISacdListener",
         "name": "",
         "type": "address"
       }

--- a/contracts/implementations/streamr/StreamrConfigurator.sol
+++ b/contracts/implementations/streamr/StreamrConfigurator.sol
@@ -14,6 +14,7 @@ contract StreamrConfigurator is AccessControlInternal {
     event StreamRegistrySet(address streamRegistry);
     event DimoStreamrNodeSet(address dimoStreamrNode);
     event DimoStreamrEnsSet(string dimoStreamrEns);
+    event StreamrSacdListenerSet(address streamrSacdListener);
 
     /**
      * @notice Sets the StreamRegistry contract address
@@ -51,5 +52,19 @@ contract StreamrConfigurator is AccessControlInternal {
     ) external onlyRole(ADMIN_ROLE) {
         StreamrConfiguratorStorage.getStorage().dimoStreamrEns = dimoStreamrEns;
         emit DimoStreamrEnsSet(dimoStreamrEns);
+    }
+
+    /**
+     * @notice Sets the Streamr SACD Listener address
+     * @dev Caller must have the ADMIN_ROLE
+     * @param streamrSacdListener The Streamr SACD Listener address
+     */
+    function setStreamrSacdListener(
+        address streamrSacdListener
+    ) external onlyRole(ADMIN_ROLE) {
+        StreamrConfiguratorStorage
+            .getStorage()
+            .streamrSacdListener = streamrSacdListener;
+        emit StreamrSacdListenerSet(streamrSacdListener);
     }
 }

--- a/contracts/implementations/streamr/StreamrSacdListener.sol
+++ b/contracts/implementations/streamr/StreamrSacdListener.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import "../../interfaces/ISacdListener.sol";
+import "./VehicleStream.sol";
+
+contract StreamrSacdListener is ISacdListener {
+
+    uint256 private constant VEHICLE_SUBSCRIBE_LIVE_DATA_PERMISSION_BITMASK = 1 << 6;
+
+    VehicleStream public _dimoRegistry;
+
+    constructor(address dimoRegistryAddress) {
+        _dimoRegistry = VehicleStream(dimoRegistryAddress);
+    }
+
+    function onSetPermissions(uint256 tokenId, address grantee, uint256 permissions, uint256 expiration) external override {
+        bool shouldHaveLiveDataPermission = permissions & VEHICLE_SUBSCRIBE_LIVE_DATA_PERMISSION_BITMASK > 0;
+        _dimoRegistry.onSetSubscribePrivilege(
+            tokenId,
+            grantee,
+            shouldHaveLiveDataPermission ? expiration : 0
+        );
+    }
+}

--- a/contracts/implementations/streamr/VehicleStream.sol
+++ b/contracts/implementations/streamr/VehicleStream.sol
@@ -261,7 +261,7 @@ contract VehicleStream is AccessControlInternal {
 
     /**
      * @notice Set a subscription permission for a user
-     * @dev Only the vehicle id owner can add new subscribers to their stream
+     * @dev Only the vehicle id owner can add new subscribers to their stream (directly or via SACD)
      * @param vehicleId Vehicle node id
      * @param subscriber Vehicle stream subscriber
      * @param expirationTime Subscription expiration timestamp
@@ -386,7 +386,12 @@ contract VehicleStream is AccessControlInternal {
         address subscriber,
         uint256 expirationTime
     ) external {
-        if (msg.sender != VehicleStorage.getStorage().idProxyAddress) {
+        address sacdListener = StreamrConfiguratorStorage
+            .getStorage()
+            .streamrSacdListener;
+
+        // Only the VehicleId NFT and the StreamrSacdListener can call this function
+        if (msg.sender != VehicleStorage.getStorage().idProxyAddress && msg.sender != sacdListener) {
             revert Errors.Unauthorized(msg.sender);
         }
 

--- a/contracts/interfaces/ISacdListener.sol
+++ b/contracts/interfaces/ISacdListener.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title ISacdListener
+ * @dev Interface for reacting to calls to the Service Access Contract Definition (SACD)
+ * ERC721 token contracts that implement the ISacdListener interface can execute custom logic when SACD permissions change
+ */
+interface ISacdListener {
+    /**
+     * @dev Handles the event when permissions are set for the ERC721 token
+     * @param tokenId The ID of the token for which permissions are being set.
+     * @param grantee The address to receive the permission
+     * @param permissions The uint256 that represents the byte array of permissions
+     * @param expiration Expiration of the permissions
+     */
+    function onSetPermissions(
+        uint256 tokenId,
+        address grantee,
+        uint256 permissions,
+        uint256 expiration
+    ) external;
+}

--- a/contracts/libraries/streamr/StreamrConfiguratorStorage.sol
+++ b/contracts/libraries/streamr/StreamrConfiguratorStorage.sol
@@ -13,6 +13,7 @@ library StreamrConfiguratorStorage {
         address streamRegistry;
         address dimoStreamrNode;
         string dimoStreamrEns;
+        address streamrSacdListener;
     }
 
     /* solhint-disable no-inline-assembly */

--- a/contracts/mocks/MockSacd.sol
+++ b/contracts/mocks/MockSacd.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
+import "../interfaces/ISacdListener.sol";
+
+
 /**
  * @title MockSacd
  * @dev Mocks the SACD contract to be used in tests
@@ -29,6 +32,9 @@ contract MockSacd {
         permissionRecords[asset][tokenId][tokenIdVersion][
             grantee
         ] = PermissionRecord(permissions, expiration, source);
+        try ISacdListener(asset).onSetPermissions(tokenId, grantee, permissions, expiration) {} catch {
+            // Ignore if the asset does not implement onSetPermissions
+        }
     }
 
     function onTransfer(address asset, uint256 tokenId) external {

--- a/scripts/data/addresses.json
+++ b/scripts/data/addresses.json
@@ -905,6 +905,7 @@
                     "0xb7bded95",
                     "0x3da44e56",
                     "0x1b1a82c8",
+                    "0x97c95b2a",
                     "0xd84baff1",
                     "0x8dca2b8e",
                     "0x9bfae6da",
@@ -986,7 +987,8 @@
                 "selectors": [
                     "0x9e594424",
                     "0x5f450e29",
-                    "0x0c3cac3b"
+                    "0x0c3cac3b",
+                    "0x69934da4"
                 ]
             },
             "VehicleStream": {


### PR DESCRIPTION
Use the SACD callback to update StreamRegistry when SACD permissions change

* designed such that adding more (similar) integrations doesn't require any further changes to SACD or VehicleId, only to the specific module, plus misc integration specific contracts
  * "similar" meaning integrations that only need to know when the permissions change. More hooks to SACD may be needed for integrations that have other needs. This change (including the SACD change in the PR https://github.com/DIMO-Network/sacd/pull/12 ) doesn't try to look into the future, only adding the minimal required for restoring the Streamr integration.
* added complexity: deployment of a new StreamrSacdListener contract. Reason is: we add callbacks to the VehicleId NFT by address only. All modules in DimoRegistry share the same address, so if in the future we want to add more listeners that talk to different integration modules, they can't clash. An option to deploying a new contract is to add both address and selector as callbacks. This one is more readable, and not really more expensive either to deploy. There is one more hop when calling it, so the address+selector callback could be a gas optimization later.
* added the deployment and setup of the StreamrSacdListener to deploy.ts as well as the test. This needs to be updated in production later (including SACD upgrade), should be straightforward.