### PR TITLE
Ex 3574 connection permission for minting synthetics

### DIFF
--- a/Selectors.md
+++ b/Selectors.md
@@ -302,6 +302,7 @@
 | 0xf8e95d55 | InvalidSdSignature() |
 | 0x87e6ac10 | OnlyNftProxy() |
 | 0xc9134785 | UintUtils__InsufficientHexLength() |
+| 0x8e4a23d6 | Unauthorized(address) |
 | 0x2d91fcb5 | VehicleNotPaired(uint256) |
 | 0xc46a5168 | VehiclePaired(uint256) |
 | 0xd92e233d | ZeroAddress() |
@@ -397,11 +398,13 @@
 | 0x77898251 | getDimoToken() |
 | 0xa2bc6cdf | getFoundation() |
 | 0x170e4293 | getManufacturerLicense() |
+| 0xc3d8478c | getSacd() |
 | 0x5b45be50 | setConnections(address) |
 | 0x4fa9ff16 | setDimoCredit(address) |
 | 0x5b6c1979 | setDimoToken(address) |
 | 0xdb3543f5 | setFoundation(address) |
 | 0xea9ae2f5 | setManufacturerLicense(address) |
+| 0xc63f7dd2 | setSacd(address) |
 
 #### Events
 | Selector | Signature |
@@ -414,6 +417,7 @@
 | 0xbd79b86f | RoleAdminChanged(bytes32,bytes32,bytes32) |
 | 0x2f878811 | RoleGranted(bytes32,address,address) |
 | 0xf6391f5c | RoleRevoked(bytes32,address,address) |
+| 0xc50082fb | SacdSet(address) |
 
 #### Errors
 | Selector | Signature |

--- a/abis/DimoRegistry.json
+++ b/abis/DimoRegistry.json
@@ -3635,6 +3635,19 @@
         "type": "event"
     },
     {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sacd",
+                "type": "address"
+            }
+        ],
+        "name": "SacdSet",
+        "type": "event"
+    },
+    {
         "inputs": [],
         "name": "getConnections",
         "outputs": [
@@ -3693,6 +3706,19 @@
             {
                 "internalType": "address",
                 "name": "manufacturerLicense",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "getSacd",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "sacd",
                 "type": "address"
             }
         ],
@@ -3760,6 +3786,19 @@
             }
         ],
         "name": "setManufacturerLicense",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "sacd",
+                "type": "address"
+            }
+        ],
+        "name": "setSacd",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"

--- a/abis/contracts/implementations/Shared.sol/Shared.json
+++ b/abis/contracts/implementations/Shared.sol/Shared.json
@@ -145,6 +145,19 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sacd",
+        "type": "address"
+      }
+    ],
+    "name": "SacdSet",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "getConnections",
     "outputs": [
@@ -203,6 +216,19 @@
       {
         "internalType": "address",
         "name": "manufacturerLicense",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSacd",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "sacd",
         "type": "address"
       }
     ],
@@ -270,6 +296,19 @@
       }
     ],
     "name": "setManufacturerLicense",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sacd",
+        "type": "address"
+      }
+    ],
+    "name": "setSacd",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/abis/contracts/implementations/nodes/SyntheticDevice.sol/SyntheticDevice.json
+++ b/abis/contracts/implementations/nodes/SyntheticDevice.sol/SyntheticDevice.json
@@ -82,6 +82,17 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "id",
         "type": "uint256"

--- a/contracts/implementations/Shared.sol
+++ b/contracts/implementations/Shared.sol
@@ -77,7 +77,7 @@ contract Shared is AccessControlInternal {
      * @dev Only an admin can set the SACD contract address
      * @param sacd The SACD contract address
      */
-    function setSACD(address sacd) external onlyRole(ADMIN_ROLE) {
+    function setSacd(address sacd) external onlyRole(ADMIN_ROLE) {
         SharedStorage.getStorage().sacd = sacd;
 
         emit SacdSet(sacd);

--- a/contracts/implementations/Shared.sol
+++ b/contracts/implementations/Shared.sol
@@ -17,6 +17,7 @@ contract Shared is AccessControlInternal {
     event DimoCreditSet(address indexed dimoCredit);
     event ManufacturerLicenseSet(address indexed manufacturerLicense);
     event ConnectionsSet(address indexed connections);
+    event SacdSet(address indexed sacd);
 
     /**
      * @notice Sets the foundation address
@@ -72,6 +73,17 @@ contract Shared is AccessControlInternal {
     }
 
     /**
+     * @notice Sets the SACD contract address
+     * @dev Only an admin can set the SACD contract address
+     * @param sacd The SACD contract address
+     */
+    function setSACD(address sacd) external onlyRole(ADMIN_ROLE) {
+        SharedStorage.getStorage().sacd = sacd;
+
+        emit SacdSet(sacd);
+    }
+
+    /**
      * @notice Gets the Foundation address
      */
     function getFoundation() external view returns (address foundation) {
@@ -108,5 +120,12 @@ contract Shared is AccessControlInternal {
      */
     function getConnections() external view returns (address connections) {
         connections = SharedStorage.getStorage().connections;
+    }
+
+    /**
+     * @notice Gets the SACD address
+     */
+    function getSacd() external view returns (address sacd) {
+        sacd = SharedStorage.getStorage().sacd;
     }
 }

--- a/contracts/implementations/nodes/SyntheticDevice.sol
+++ b/contracts/implementations/nodes/SyntheticDevice.sol
@@ -188,11 +188,8 @@ contract SyntheticDevice is
             .idProxyAddress;
         address sdIdProxyAddress = sds.idProxyAddress;
 
-        if (
-            !INFT(IntegrationStorage.getStorage().idProxyAddress).exists(
-                data.connectionId
-            )
-        ) revert InvalidParentNode(data.connectionId);
+        if (!INFT(sharedStorage.connections).exists(data.connectionId))
+            revert InvalidParentNode(data.connectionId);
         if (
             !ISacd(sharedStorage.sacd).hasPermission(
                 sharedStorage.connections,

--- a/contracts/libraries/SharedStorage.sol
+++ b/contracts/libraries/SharedStorage.sol
@@ -15,6 +15,8 @@ library SharedStorage {
         address dimoToken;
         address manufacturerLicense;
         address connections;
+        // Address of the SACD contract, governing permissions for many NFTs.
+        address sacd;
     }
 
     /* solhint-disable no-inline-assembly */

--- a/contracts/mocks/MockSacd.sol
+++ b/contracts/mocks/MockSacd.sol
@@ -31,6 +31,22 @@ contract MockSacd {
         ] = PermissionRecord(permissions, expiration, source);
     }
 
+    function hasPermission(
+        address asset,
+        uint256 tokenId,
+        address grantee,
+        uint8 permissionIndex
+    ) external view returns (bool) {
+        uint256 tokenIdVersion = tokenIdToVersion[asset][tokenId];
+        PermissionRecord memory pr = permissionRecords[asset][tokenId][
+            tokenIdVersion
+        ][grantee];
+
+        return
+            block.timestamp < pr.expiration &&
+            (pr.permissions >> (2 * permissionIndex)) & 3 == 3;
+    }
+
     function onTransfer(address asset, uint256 tokenId) external {
         tokenIdToVersion[asset][tokenId]++;
     }

--- a/contracts/mocks/MockSacd.sol
+++ b/contracts/mocks/MockSacd.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
+import {IERC721} from "@openzeppelin/contracts/interfaces/IERC721.sol";
+
 /**
  * @title MockSacd
  * @dev Mocks the SACD contract to be used in tests
@@ -37,6 +39,14 @@ contract MockSacd {
         address grantee,
         uint8 permissionIndex
     ) external view returns (bool) {
+        try IERC721(asset).ownerOf(tokenId) returns (address tokenIdOwner) {
+            if (tokenIdOwner == grantee) {
+                return true;
+            }
+        } catch {
+            return false;
+        }
+
         uint256 tokenIdVersion = tokenIdToVersion[asset][tokenId];
         PermissionRecord memory pr = permissionRecords[asset][tokenId][
             tokenIdVersion

--- a/test/DevAdmin.test.ts
+++ b/test/DevAdmin.test.ts
@@ -30,6 +30,7 @@ import {
   MockDimoToken,
   MockDimoCredit,
   MockManufacturerLicense,
+  MockSacd,
   MockConnections,
   DevAdmin,
 } from '../typechain-types';
@@ -59,6 +60,7 @@ describe('DevAdmin', function () {
   let mapperInstance: Mapper;
   let sharedInstance: Shared;
   let mockDimoTokenInstance: MockDimoToken;
+  let mockSacdInstance: MockSacd;
   let mockManufacturerLicenseInstance: MockManufacturerLicense;
   let mockDimoCreditInstance: MockDimoCredit;
   let mockConnectionsInstance: MockConnections;
@@ -189,6 +191,10 @@ describe('DevAdmin', function () {
     );
     mockDimoCreditInstance = await MockDimoCreditFactory.connect(admin).deploy();
 
+    // Deploy MockSacd contract
+    const MockSacdFactory = await ethers.getContractFactory('MockSacd');
+    mockSacdInstance = await MockSacdFactory.connect(admin).deploy();
+
     // Deploy MockConnections contract
     const MockConnectionsFactory = await ethers.getContractFactory(
       'MockConnections'
@@ -266,6 +272,9 @@ describe('DevAdmin', function () {
     await sharedInstance
       .connect(admin)
       .setConnections(await mockConnectionsInstance.getAddress());
+    await sharedInstance
+      .connect(admin)
+      .setSacd(await mockSacdInstance.getAddress());
 
     // Setup Charging variables
     await chargingInstance
@@ -1212,7 +1221,7 @@ describe('DevAdmin', function () {
         };
 
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(localMintSdInput);
 
         await expect(devAdminInstance.connect(admin).adminBurnVehicles([1, 2]))
@@ -1469,7 +1478,7 @@ describe('DevAdmin', function () {
         };
 
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(localMintSdInput);
       });
 
@@ -1799,7 +1808,7 @@ describe('DevAdmin', function () {
         };
 
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(localMintSdInput);
 
         await expect(
@@ -2385,10 +2394,10 @@ describe('DevAdmin', function () {
       ['mintVehicleWithDeviceDefinition(uint256,address,string,(string,string)[])'](1, user2.address, C.mockDdId1, C.mockVehicleAttributeInfoPairs);
 
       await syntheticDeviceInstance
-        .connect(admin)
+        .connect(connectionOwner1)
         .mintSyntheticDeviceSign(localMintSdInput1);
       await syntheticDeviceInstance
-        .connect(admin)
+        .connect(connectionOwner1)
         .mintSyntheticDeviceSign(localMintSdInput2);
     });
 

--- a/test/NFTs/SyntheticDeviceId.test.ts
+++ b/test/NFTs/SyntheticDeviceId.test.ts
@@ -1,6 +1,7 @@
 import chai from 'chai';
 import { ethers } from 'hardhat';
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers';
+import { time } from '@nomicfoundation/hardhat-network-helpers';
 
 import {
   DIMORegistry,
@@ -51,6 +52,7 @@ describe('SyntheticDeviceId', async function () {
   let mockConnectionsInstance: MockConnections;
 
   let DIMO_REGISTRY_ADDRESS: string;
+  let expiresAtDefault: number;
 
   let admin: HardhatEthersSigner;
   let nonAdmin: HardhatEthersSigner;
@@ -138,6 +140,13 @@ describe('SyntheticDeviceId', async function () {
     await sdIdInstance
       .connect(admin)
       .grantRole(C.NFT_MINTER_ROLE, DIMO_REGISTRY_ADDRESS);
+    
+    // Grant synthetic device minting permission
+
+    expiresAtDefault = (await time.latest()) + 31556926; // + 1 year
+    await sharedInstance.connect(admin).setSacd(mockSacdInstance);
+
+    await mockSacdInstance.setPermissions(mockConnectionsInstance, C.CONNECTION_ID_1, admin, 3, expiresAtDefault, '');
 
     // Set NFT Proxies
     await manufacturerInstance

--- a/test/NFTs/VehicleId.test.ts
+++ b/test/NFTs/VehicleId.test.ts
@@ -237,6 +237,9 @@ describe('VehicleId', async function () {
     await sharedInstance
       .connect(admin)
       .setConnections(await mockConnectionsInstance.getAddress());
+    await sharedInstance
+      .connect(admin)
+      .setSacd(await mockSacdInstance.getAddress());
 
     // Setup Charging variables
     await chargingInstance
@@ -741,7 +744,7 @@ describe('VehicleId', async function () {
         };
 
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(localMintSdInput);
 
         await expect(vehicleIdInstance.connect(user1).burn(1))

--- a/test/nodes/SyntheticDevice.test.ts
+++ b/test/nodes/SyntheticDevice.test.ts
@@ -18,6 +18,7 @@ import {
   Shared,
   MockDimoToken,
   MockDimoCredit,
+  MockSacd,
   MockConnections
 } from '../../typechain-types';
 import {
@@ -48,6 +49,7 @@ describe('SyntheticDevice', function () {
   let sharedInstance: Shared;
   let mockDimoTokenInstance: MockDimoToken;
   let mockDimoCreditInstance: MockDimoCredit;
+  let mockSacdInstance: MockSacd;
   let mockConnectionsInstance: MockConnections;
   let manufacturerIdInstance: ManufacturerId;
   let vehicleIdInstance: VehicleId;
@@ -130,6 +132,10 @@ describe('SyntheticDevice', function () {
     );
     mockDimoCreditInstance = await MockDimoCreditFactory.connect(admin).deploy();
 
+    // Deploy MockSacd contract
+    const MockSacdFactory = await ethers.getContractFactory('MockSacd');
+    mockSacdInstance = await MockSacdFactory.connect(admin).deploy();
+
     // Deploy MockConnections contract
     const MockConnectionsFactory = await ethers.getContractFactory(
       'MockConnections'
@@ -194,6 +200,9 @@ describe('SyntheticDevice', function () {
     await sharedInstance
       .connect(admin)
       .setConnections(await mockConnectionsInstance.getAddress());
+    await sharedInstance
+      .connect(admin)
+      .setSacd(await mockSacdInstance.getAddress());
 
     // Setup Charging variables
     await chargingInstance
@@ -630,22 +639,12 @@ describe('SyntheticDevice', function () {
         incorrectMintInput = { ...correctMintInput };
       });
 
-      it('Should revert if caller does not have MINT_SD_ROLE', async () => {
-        await expect(
-          syntheticDeviceInstance
-            .connect(nonAdmin)
-            .mintSyntheticDeviceSign(correctMintInput),
-        ).to.be.revertedWith(
-          `AccessControl: account ${nonAdmin.address.toLowerCase()} is missing role ${C.MINT_SD_ROLE
-          }`,
-        );
-      });
       it('Should revert if parent node is not a connection ID', async () => {
         incorrectMintInput.connectionId = '99';
 
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(incorrectMintInput),
         )
           .to.be.revertedWithCustomError(
@@ -659,7 +658,7 @@ describe('SyntheticDevice', function () {
 
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(incorrectMintInput),
         )
           .to.be.revertedWithCustomError(syntheticDeviceInstance, 'InvalidNode')
@@ -672,12 +671,12 @@ describe('SyntheticDevice', function () {
           .connect(admin)
         ['mintVehicleWithDeviceDefinition(uint256,address,string,(string,string)[])'](1, user1.address, C.mockDdId1, C.mockVehicleAttributeInfoPairs);
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(correctMintInput);
 
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(incorrectMintInput),
         )
           .to.be.revertedWithCustomError(
@@ -695,7 +694,7 @@ describe('SyntheticDevice', function () {
 
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(incorrectMintInput),
         ).to.be.revertedWithCustomError(
           syntheticDeviceInstance,
@@ -708,7 +707,7 @@ describe('SyntheticDevice', function () {
 
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(incorrectMintInput),
         )
           .to.be.revertedWithCustomError(
@@ -723,12 +722,12 @@ describe('SyntheticDevice', function () {
         incorrectMintInput.syntheticDeviceAddr = sdAddress2.address;
 
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(correctMintInput);
 
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(incorrectMintInput),
         )
           .to.be.revertedWithCustomError(
@@ -755,7 +754,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -777,7 +776,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -799,7 +798,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -821,7 +820,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -842,7 +841,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -863,7 +862,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -888,7 +887,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -910,7 +909,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -932,7 +931,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -954,7 +953,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -975,7 +974,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -996,7 +995,7 @@ describe('SyntheticDevice', function () {
 
             await expect(
               syntheticDeviceInstance
-                .connect(admin)
+                .connect(connectionOwner1)
                 .mintSyntheticDeviceSign(incorrectMintInput),
             ).to.be.revertedWithCustomError(
               syntheticDeviceInstance,
@@ -1010,7 +1009,7 @@ describe('SyntheticDevice', function () {
     context('State', () => {
       it('Should correctly set parent node', async () => {
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(correctMintInput);
 
         const parentNode = await nodesInstance.getParentNode(
@@ -1022,14 +1021,14 @@ describe('SyntheticDevice', function () {
       });
       it('Should correctly set node owner', async () => {
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(correctMintInput);
 
         expect(await sdIdInstance.ownerOf(1)).to.be.equal(user1.address);
       });
       it('Should correctly set device address', async () => {
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(correctMintInput);
 
         const id = await syntheticDeviceInstance.getSyntheticDeviceIdByAddress(
@@ -1040,7 +1039,7 @@ describe('SyntheticDevice', function () {
       });
       it('Should correctly set infos', async () => {
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(correctMintInput);
 
         expect(
@@ -1060,7 +1059,7 @@ describe('SyntheticDevice', function () {
       });
       it('Should correctly map the synthetic device to the vehicle', async () => {
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(correctMintInput);
 
         expect(
@@ -1073,7 +1072,7 @@ describe('SyntheticDevice', function () {
       });
       it('Should correctly map the vehicle to the synthetic device', async () => {
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(correctMintInput);
 
         expect(
@@ -1090,7 +1089,7 @@ describe('SyntheticDevice', function () {
       it('Should emit SyntheticDeviceNodeMinted event with correct params', async () => {
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(correctMintInput),
         )
           .to.emit(syntheticDeviceInstance, 'SyntheticDeviceNodeMinted')
@@ -1099,7 +1098,7 @@ describe('SyntheticDevice', function () {
       it('Should emit SyntheticDeviceAttributeSet events with correct params', async () => {
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(correctMintInput),
         )
           .to.emit(syntheticDeviceInstance, 'SyntheticDeviceAttributeSet')
@@ -1121,7 +1120,7 @@ describe('SyntheticDevice', function () {
 
         await expect(
           syntheticDeviceInstance
-            .connect(admin)
+            .connect(connectionOwner1)
             .mintSyntheticDeviceSign(correctMintInput),
         ).to.not.emit(syntheticDeviceInstance, 'SyntheticDeviceAttributeSet');
       });
@@ -1203,7 +1202,7 @@ describe('SyntheticDevice', function () {
 
     beforeEach(async () => {
       await syntheticDeviceInstance
-        .connect(admin)
+        .connect(connectionOwner1)
         .mintSyntheticDeviceSign(mintInput1);
     });
 
@@ -1251,7 +1250,7 @@ describe('SyntheticDevice', function () {
           .connect(admin)
         ['mintVehicleWithDeviceDefinition(uint256,address,string,(string,string)[])'](1, user1.address, C.mockDdId1, C.mockVehicleAttributeInfoPairs);
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(mintInput2);
 
         await expect(
@@ -1280,7 +1279,7 @@ describe('SyntheticDevice', function () {
           .connect(admin)
         ['mintVehicleWithDeviceDefinition(uint256,address,string,(string,string)[])'](1, user1.address, C.mockDdId1, C.mockVehicleAttributeInfoPairs);
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(mintInput2);
 
         await expect(
@@ -1565,7 +1564,7 @@ describe('SyntheticDevice', function () {
 
     beforeEach(async () => {
       await syntheticDeviceInstance
-        .connect(admin)
+        .connect(connectionOwner1)
         .mintSyntheticDeviceSign(mintInput);
     });
 
@@ -1712,7 +1711,7 @@ describe('SyntheticDevice', function () {
 
     beforeEach(async () => {
       await syntheticDeviceInstance
-        .connect(admin)
+        .connect(connectionOwner1)
         .mintSyntheticDeviceSign(mintInput);
     });
 
@@ -1768,7 +1767,7 @@ describe('SyntheticDevice', function () {
 
     beforeEach(async () => {
       await syntheticDeviceInstance
-        .connect(admin)
+        .connect(connectionOwner1)
         .mintSyntheticDeviceSign(mintInput);
     });
 

--- a/test/nodes/Vehicle.test.ts
+++ b/test/nodes/Vehicle.test.ts
@@ -233,6 +233,9 @@ describe('Vehicle', function () {
     await sharedInstance
       .connect(admin)
       .setConnections(await mockConnectionsInstance.getAddress());
+    await sharedInstance
+      .connect(admin)
+      .setSacd(await mockSacdInstance.getAddress());
 
     // Setup Charging variables
     await chargingInstance
@@ -1339,7 +1342,7 @@ describe('Vehicle', function () {
         };
 
         await syntheticDeviceInstance
-          .connect(admin)
+          .connect(connectionOwner1)
           .mintSyntheticDeviceSign(localMintSdInput);
 
         await expect(

--- a/utils/constants/NftArgs.ts
+++ b/utils/constants/NftArgs.ts
@@ -12,6 +12,9 @@ export const MANUFACTURER_FACTORY_RESET_PRIVILEGE = '3';
 export const MANUFACTURER_REPROVISION_PRIVILEGE = '4';
 export const MANUFACTURER_INSERT_DD_PRIVILEGE = '5';
 
+// Connection permissions
+export const CONNECTION_SD_MINTER_PERMISSION = '0';
+
 export const INTEGRATION_NFT_NAME = 'Integration NFT';
 export const INTEGRATION_NFT_SYMBOL = 'INFT';
 export const INTEGRATION_NFT_BASE_URI = 'https://dimo.zone/integration/';


### PR DESCRIPTION
Here we make a hard cut: `MINT_SD_ROLE` doesn't work anymore. We'd have to assign the minting permission to the main metatransactor wallets and whatever connection wallets are out there.

Remaining items:

* We've fixed one test, but 37 others are failing for the obvious reason
* We must add similar logic to the "multiple minter"